### PR TITLE
Change format to be part of the ExternalStage, not the CopyInto command.

### DIFF
--- a/base.py
+++ b/base.py
@@ -180,7 +180,6 @@ class SnowflakeCompiler(compiler.SQLCompiler):
                 " SET %s" % sets if merge_into_clause.set else "")
 
     def visit_copy_into(self, copy_into, **kw):
-        formatter = copy_into.formatter._compiler_dispatch(self, **kw)
         into = (copy_into.into if isinstance(copy_into.into, Table)
                 else copy_into.into._compiler_dispatch(self, **kw))
         from_ = None
@@ -214,7 +213,7 @@ class SnowflakeCompiler(compiler.SQLCompiler):
             options += " {}".format(credentials)
         if encryption:
             options += " {}".format(encryption)
-        return "COPY INTO {} FROM {} {}{}".format(into, from_, formatter, options)
+        return "COPY INTO {} FROM {} {}".format(into, from_, options)
 
     def visit_copy_formatter(self, formatter, **kw):
         options_list = list(formatter.options.items())

--- a/custom_commands.py
+++ b/custom_commands.py
@@ -93,17 +93,24 @@ class CopyInto(UpdateBase):
     __visit_name__ = 'copy_into'
     _bind = None
 
-    def __init__(self, from_, into):
+    def __init__(self, from_, into, formatter=None):
         self.from_ = from_
         self.into = into
+        self.formatter = formatter
         self.copy_options = {}
 
     def __repr__(self):
         options = (' ' + ' '.join(["{} = {}".format(n, str(v)) for n, v in
                                    self.copy_options.items()])) if self.copy_options else ''
+
+        if self.formatter is not None:
+            return "COPY INTO {} FROM {} {}{}".format(self.into.__str__(),
+                                                      self.from_.__repr__(),
+                                                      self.formatter.__repr__(),
+                                                      options)
         return "COPY INTO {} FROM {} {}".format(self.into.__str__(),
-                                                  self.from_.__repr__(),
-                                                  options)
+                                                self.from_.__repr__(),
+                                                options)
 
     def bind(self):
         return None

--- a/custom_commands.py
+++ b/custom_commands.py
@@ -108,10 +108,10 @@ class CopyInto(UpdateBase):
     def bind(self):
         return None
 
-    def force(self, overwrite):
-        if not isinstance(overwrite, bool):
+    def force(self, force):
+        if not isinstance(force, bool):
             raise TypeError("Parameter force should  be a boolean value")
-        self.copy_options.update({'FORCE': translate_bool(overwrite)})
+        self.copy_options.update({'FORCE': translate_bool(force)})
 
     def single(self, single_file):
         if not isinstance(single_file, bool):

--- a/custom_commands.py
+++ b/custom_commands.py
@@ -108,10 +108,10 @@ class CopyInto(UpdateBase):
     def bind(self):
         return None
 
-    def overwrite(self, overwrite):
+    def force(self, overwrite):
         if not isinstance(overwrite, bool):
             raise TypeError("Parameter overwrite should  be a boolean value")
-        self.copy_options.update({'OVERWRITE': translate_bool(overwrite)})
+        self.copy_options.update({'FORCE': translate_bool(overwrite)})
 
     def single(self, single_file):
         if not isinstance(single_file, bool):

--- a/custom_commands.py
+++ b/custom_commands.py
@@ -93,18 +93,16 @@ class CopyInto(UpdateBase):
     __visit_name__ = 'copy_into'
     _bind = None
 
-    def __init__(self, from_, into, formatter):
+    def __init__(self, from_, into):
         self.from_ = from_
         self.into = into
-        self.formatter = formatter
         self.copy_options = {}
 
     def __repr__(self):
         options = (' ' + ' '.join(["{} = {}".format(n, str(v)) for n, v in
                                    self.copy_options.items()])) if self.copy_options else ''
-        return "COPY INTO {} FROM {} {}{}".format(self.into.__str__(),
+        return "COPY INTO {} FROM {} {}".format(self.into.__str__(),
                                                   self.from_.__repr__(),
-                                                  self.formatter.__repr__(),
                                                   options)
 
     def bind(self):
@@ -384,21 +382,24 @@ class ExternalStage(ClauseElement, FromClauseRole):
     def prepare_path(path):
         return "/{}".format(path) if not path.startswith("/") else path
 
-    def __init__(self, name, path=None, namespace=None):
+    def __init__(self, name, path=None, namespace=None, file_format=None):
         self.name = name
         self.path = self.prepare_path(path) if path else ""
         self.namespace = self.prepare_namespace(namespace) if namespace else ""
+        self.file_format = file_format
 
     def __repr__(self):
-        return "@{}{}{}".format(self.namespace, self.name, self.path)
+        if self.file_format is None:
+            return "@{}{}{}".format(self.namespace, self.name, self.path)
+        return "@{}{}{} (file_format => {})".format(self.namespace, self.name, self.path, self.file_format)
 
     @classmethod
-    def from_root_stage(cls, root_stage, path):
+    def from_root_stage(cls, root_stage, path, file_format=None):
         """
         Extend an existing root stage (with or without path) with an
         additional sub-path
         """
-        return cls(root_stage.name, root_stage.path + "/" + path, root_stage.namespace)
+        return cls(root_stage.name, root_stage.path + "/" + path, root_stage.namespace, file_format)
 
 
 class CreateFileFormat(DDLElement):

--- a/custom_commands.py
+++ b/custom_commands.py
@@ -110,7 +110,7 @@ class CopyInto(UpdateBase):
 
     def force(self, overwrite):
         if not isinstance(overwrite, bool):
-            raise TypeError("Parameter overwrite should  be a boolean value")
+            raise TypeError("Parameter force should  be a boolean value")
         self.copy_options.update({'FORCE': translate_bool(overwrite)})
 
     def single(self, single_file):


### PR DESCRIPTION
This pull request fixes the select statement from external table.
For example:
```
SELECT *
FROM @EXTERNAL_STAGE/subfolder/import.parquet 
```
Does not work. The parquet  file_format should be specified:
```
SELECT *
FROM @EXTERNAL_STAGE/subfolder/import.parquet 
(file_format => PARQUET)
```